### PR TITLE
Add French translation + Some fixes

### DIFF
--- a/data/com.github.lainsce.palaura.appdata.xml
+++ b/data/com.github.lainsce.palaura.appdata.xml
@@ -9,6 +9,7 @@
         <p>Find any word's definition, and details about it, with this handy dictionary by your side</p>
         <ul>
             <li>Quit anytime with the shortcut Ctrl + Q</li>
+            <li>Available in English and Spanish</li>
         </ul>
     </description>
     <provides>

--- a/data/com.github.lainsce.palaura.desktop
+++ b/data/com.github.lainsce.palaura.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Palaura
-Comment=Find any word\'s definition with this handy dictionary
+Comment=Find any word definition with this handy dictionary
 Exec=com.github.lainsce.palaura
 Icon=com.github.lainsce.palaura
 Keywords=Words;Dictionary;Search;

--- a/data/com.github.lainsce.palaura.desktop
+++ b/data/com.github.lainsce.palaura.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Palaura
-Comment=Find any word's definition with this handy dictionary
+Comment=Find any word\'s definition with this handy dictionary
 Exec=com.github.lainsce.palaura
 Icon=com.github.lainsce.palaura
 Keywords=Words;Dictionary;Search;

--- a/data/com.github.lainsce.palaura.desktop
+++ b/data/com.github.lainsce.palaura.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Palaura
-Comment=Find any word definition with this handy dictionary
+Comment=Find any word's definition with this handy dictionary
 Exec=com.github.lainsce.palaura
 Icon=com.github.lainsce.palaura
 Keywords=Words;Dictionary;Search;

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,4 +1,3 @@
-src/Constants/Stylesheet.vala
 src/Core/Definition.vala
 src/Core/DictCore.vala
 src/Views/View.vala

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -8,3 +8,5 @@ src/Views/DefinitionView.vala
 src/Widgets/WordListRow.vala
 src/Application.vala
 src/MainWindow.vala
+data/com.github.lainsce.palaura.appdata.xml
+data/com.github.lainsce.palaura.desktop

--- a/po/com.github.lainsce.palaura.pot
+++ b/po/com.github.lainsce.palaura.pot
@@ -37,6 +37,10 @@ msgstr ""
 msgid "Quit anytime with the shortcut Ctrl + Q"
 msgstr ""
 
+#: data/com.github.lainsce.palaura.appdata.xml:12
+msgid "Available in English and Spanish"
+msgstr ""
+
 #: data/com.github.lainsce.palaura.desktop:3
 msgid "Find any word definition with this handy dictionary"
 msgstr ""

--- a/po/com.github.lainsce.palaura.pot
+++ b/po/com.github.lainsce.palaura.pot
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Copyright (C) YEAR THE com.github.lainsce.palaura'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the com.github.lainsce.palaura package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
@@ -17,10 +17,66 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:38
+#: src/Application.vala:10
+#: src/MainWindow.vala:17
+#: src/MainWindow.vala:72
 msgid "Palaura"
 msgstr ""
 
-#: src/MainWindow.vala:124
-msgid ""
+#: src/MainWindow.vala:52
+msgid "Search words"
+msgstr ""
+
+#: src/MainWindow.vala:55
+#: src/MainWindow.vala:141
+#: src/Views/NormalView.vala:14
+msgid "Home"
+msgstr ""
+
+#: src/MainWindow.vala:63
+msgid "Settings"
+msgstr ""
+
+#: src/Views/DefinitionView.vala:104
+msgid "Definition"
+msgstr ""
+
+#: src/Views/NormalView.vala:6
+msgid "Search a Word"
+msgstr ""
+
+#: src/Views/NormalView.vala:7
+msgid "Use the searchbar to find the word you're looking for."
+msgstr ""
+
+#: src/Views/SearchView.vala:41
+msgid "Finding your word, please wait..."
+msgstr ""
+
+#: src/Views/SearchView.vala:53
+msgid "Search"
+msgstr ""
+
+#: src/Views/WordListView.vala:10
+msgid "No words found"
+msgstr ""
+
+#: src/Views/WordListView.vala:10
+msgid "Try fixing your search term."
+msgstr ""
+
+#: src/Widgets/Preferences.vala:38
+msgid "Dictionary Preferences"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:39
+msgid "Lookup language:"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:41
+msgid "English"
+msgstr ""
+
+#: src/Widgets/Preferences.vala:42
+msgid "Spanish"
 msgstr ""

--- a/po/com.github.lainsce.palaura.pot
+++ b/po/com.github.lainsce.palaura.pot
@@ -72,7 +72,7 @@ msgid "Use the searchbar to find the word you're looking for."
 msgstr ""
 
 #: src/Views/SearchView.vala:41
-msgid "Finding your word, please wait..."
+msgid "Finding your word, please wait…"
 msgstr ""
 
 #: src/Views/SearchView.vala:53

--- a/po/com.github.lainsce.palaura.pot
+++ b/po/com.github.lainsce.palaura.pot
@@ -17,10 +17,32 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: data/com.github.lainsce.palaura.appdata.xml:6
+#: data/com.github.lainsce.palaura.desktop:2
 #: src/Application.vala:10
 #: src/MainWindow.vala:17
 #: src/MainWindow.vala:72
 msgid "Palaura"
+msgstr ""
+
+#: data/com.github.lainsce.palaura.appdata.xml:7
+msgid "Find any word's definition with this handy dictionary"
+msgstr ""
+
+#: data/com.github.lainsce.palaura.appdata.xml:9
+msgid "Find any word's definition, and details about it, with this handy dictionary by your side"
+msgstr ""
+
+#: data/com.github.lainsce.palaura.appdata.xml:11
+msgid "Quit anytime with the shortcut Ctrl + Q"
+msgstr ""
+
+#: data/com.github.lainsce.palaura.desktop:3
+msgid "Find any word definition with this handy dictionary"
+msgstr ""
+
+#: data/com.github.lainsce.palaura.desktop:6
+msgid "Words;Dictionary;Search;"
 msgstr ""
 
 #: src/MainWindow.vala:52

--- a/po/fr.po
+++ b/po/fr.po
@@ -37,6 +37,10 @@ msgstr "Trouvez la définition de n'importe quel mot, et des détails à son suj
 msgid "Quit anytime with the shortcut Ctrl + Q"
 msgstr "Quittez à tout moment avec le raccourci Ctrl + Q"
 
+#: data/com.github.lainsce.palaura.appdata.xml:12
+msgid "Available in English and Spanish"
+msgstr "Disponible en Anglais et en Espagnol"
+
 #: data/com.github.lainsce.palaura.desktop:3
 msgid "Find any word definition with this handy dictionary"
 msgstr "Trouvez n'importe quelle définition de mot avec ce dictionnaire pratique"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,0 +1,104 @@
+# French translations for com.github.lainsce.palaura package.
+# Copyright (C) 2019 THE com.github.lainsce.palaura'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the com.github.lainsce.palaura package.
+# NathanBnm, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: com.github.lainsce.palaura\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-09-07 02:27-0300\n"
+"PO-Revision-Date: 2019-01-25 17:48+0100\n"
+"Last-Translator: NathanBnm\n"
+"Language-Team: Français\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/com.github.lainsce.palaura.appdata.xml:6
+#: data/com.github.lainsce.palaura.desktop:2
+#: src/Application.vala:10
+#: src/MainWindow.vala:17
+#: src/MainWindow.vala:72
+msgid "Palaura"
+msgstr "Palaura"
+
+#: data/com.github.lainsce.palaura.appdata.xml:7
+msgid "Find any word's definition with this handy dictionary"
+msgstr "Trouvez la définition de n'importe quel mot avec ce dictionnaire pratique"
+
+#: data/com.github.lainsce.palaura.appdata.xml:9
+msgid "Find any word's definition, and details about it, with this handy dictionary by your side"
+msgstr "Trouvez la définition de n'importe quel mot, et des détails à son sujet, avec ce dictionnaire pratique à vos côtés"
+
+#: data/com.github.lainsce.palaura.appdata.xml:11
+msgid "Quit anytime with the shortcut Ctrl + Q"
+msgstr "Quittez à tout moment avec le raccourci Ctrl + Q"
+
+#: data/com.github.lainsce.palaura.desktop:3
+msgid "Find any word definition with this handy dictionary"
+msgstr "Trouvez n'importe quelle définition de mot avec ce dictionnaire pratique"
+
+#: data/com.github.lainsce.palaura.desktop:6
+msgid "Words;Dictionary;Search;"
+msgstr "Mots;Dictionnaire;Recherche;"
+
+#: src/MainWindow.vala:52
+msgid "Search words"
+msgstr "Rechercher des mots"
+
+#: src/MainWindow.vala:55
+#: src/MainWindow.vala:141
+#: src/Views/NormalView.vala:14
+msgid "Home"
+msgstr "Accueil"
+
+#: src/MainWindow.vala:63
+msgid "Settings"
+msgstr "Paramètres"
+
+#: src/Views/DefinitionView.vala:104
+msgid "Definition"
+msgstr "Définition"
+
+#: src/Views/NormalView.vala:6
+msgid "Search a Word"
+msgstr "Chercher un mot"
+
+#: src/Views/NormalView.vala:7
+msgid "Use the searchbar to find the word you're looking for."
+msgstr "Utilisez la barre de recherche pour trouver le mot que vous cherchez."
+
+#: src/Views/SearchView.vala:41
+msgid "Finding your word, please wait…"
+msgstr "Recherhe de votre mot, veuillez patienter…"
+
+#: src/Views/SearchView.vala:53
+msgid "Search"
+msgstr "Rechercher"
+
+#: src/Views/WordListView.vala:10
+msgid "No words found"
+msgstr "Aucun mot trouvé"
+
+#: src/Views/WordListView.vala:10
+msgid "Try fixing your search term."
+msgstr "Essayez de corriger vos termes de recherche."
+
+#: src/Widgets/Preferences.vala:38
+msgid "Dictionary Preferences"
+msgstr "Préférence de dictionnaire"
+
+#: src/Widgets/Preferences.vala:39
+msgid "Lookup language:"
+msgstr "Langue de recherche"
+
+#: src/Widgets/Preferences.vala:41
+msgid "English"
+msgstr "Anglais"
+
+#: src/Widgets/Preferences.vala:42
+msgid "Spanish"
+msgstr "Espagnol"

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -38,7 +38,7 @@ public class Palaura.SearchView : Palaura.View {
         spinner.set_size_request (32, 32);
         spinner_container.pack_start (spinner);
 
-        label_loading_info = new Gtk.Label ("Finding your word, please wait...");
+        label_loading_info = new Gtk.Label ("Finding your word, please wait…");
         spinner_container.pack_start (label_loading_info);
 
 


### PR DESCRIPTION
### Changelog

- Updated `POTFILES`
- Added strings into `com.github.lainsce.palaura.pot` file,
- Added French translation in `fr.po`,
- Fixed `…` typo in `SearchView.vala` file and translation files,
- Added "Available in English and Spanish" precision in `appdata.xml` file and into translation files

Let me know if there is some error or if some strings are missing. I took the opportunity to search but it seems that French is not available with the Oxford Dictionaries API as described on this page: https://developer.oxforddictionaries.com/documentation/languages. (That's also why I added the precision in the app description.)

Perhaps it would be interesting to add German, which is a fairly common language too.