### PR TITLE
Use Gtk.Application instead of deprecated Granite.Application

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -1,6 +1,4 @@
-using Granite.Widgets;
-
-public class Palaura.Application : Granite.Application {
+public class Palaura.Application : Gtk.Application {
     public static GLib.Settings gsettings;
     public Palaura.MainWindow main_window;
 
@@ -10,9 +8,6 @@ public class Palaura.Application : Granite.Application {
 
     construct {
         application_id = "com.github.lainsce.palaura";
-        program_name = _("Palaura");
-        app_launcher = "com.github.lainsce.palaura.desktop";
-        exec_name = "com.github.lainsce.palaura";
     }
 
     public override void activate () {


### PR DESCRIPTION
[Granite.Application is deprecated](https://github.com/elementary/granite/blob/3c25b6c95e5ddf3fcc3bdf8bf1014f6d2246e677/lib/Application.vala#L25) since 0.5.0 and should not be used anymore.
