### PR TITLE
fix text category parse

### DIFF
--- a/src/Core/Definition.vala
+++ b/src/Core/Definition.vala
@@ -12,8 +12,11 @@ public class Palaura.Core.Definition : Object {
         if (root.has_member ("text"))
             obj.text = root.get_string_member ("text");
 
-        if (root.has_member ("lexicalCategory"))
-            obj.lexical_category = root.get_string_member ("lexicalCategory");
+        if (root.has_member ("lexicalCategory")) {
+            Json.Object category = root.get_object_member ("lexicalCategory");
+            if (category.has_member ("text"))
+                obj.lexical_category = category.get_string_member ("text");
+        }
 
         if (root.has_member ("pronunciations")) {
             Json.Array pronunciations = root.get_array_member ("pronunciations");

--- a/src/Views/DefinitionView.vala
+++ b/src/Views/DefinitionView.vala
@@ -65,9 +65,9 @@ public class Palaura.DefinitionView : Palaura.View {
                 } else {
                     pronunciation_str += "; ";
                 }
-    
+
                 pronunciation_str += pronunciations[i].phonetic_spelling;
-    
+
                 if (i == pronunciations.length - 1) {
                     pronunciation_str += "/";
                 }
@@ -79,9 +79,10 @@ public class Palaura.DefinitionView : Palaura.View {
 
         buffer.insert(ref iter, "\n", -1);
 
-        if(definition.lexical_category != null)
+        if(definition.lexical_category != null) {
             buffer.insert_with_tags (ref iter, @"▰  ", -1, tag_sense_lexicon);
             buffer.insert_with_tags (ref iter, @"$(definition.lexical_category)", -1, tag_lexical_category);
+        }
 
         buffer.insert(ref iter, "\n", -1);
 


### PR DESCRIPTION
According to the documentation, lexicalCategory is not a string but a object:
https://developer.oxforddictionaries.com/documentation#!/Entries/get_entries_source_lang_word_id

Also I think there are missing brackets in `DifinitionView.vala` so I added them.